### PR TITLE
Adopt new track field format

### DIFF
--- a/ragent_api/incoming_messages_handler.rb
+++ b/ragent_api/incoming_messages_handler.rb
@@ -9,7 +9,7 @@ module RagentIncomingMessage
   def self.valid_params(params)
     if params['meta'] == nil or params['payload'] == nil
       begin
-        raise "RagentIncomingMessage: bad incomming params structure: #{params}"
+        raise "RagentIncomingMessage: bad incoming params structure: #{params}"
       rescue Exception => e
         PUNK.start('valid')
         RAGENT.api.mdi.tools.print_ruby_exception(e)
@@ -39,7 +39,7 @@ module RagentIncomingMessage
     end
 
     PUNK.start('new')
-    RAGENT.api.mdi.tools.log.debug("\n\n\n\nServer: new incomming presence:\n#{params}")
+    RAGENT.api.mdi.tools.log.debug("\n\n\n\nServer: new incoming presence:\n#{params}")
     PUNK.end('new','ok','in',"SERVER <- PRESENCE : receive new presence")
     SDK_STATS.stats['server']['received'][0] += 1
 
@@ -80,7 +80,7 @@ module RagentIncomingMessage
         end
 
         PUNK.start('new')
-        RAGENT.api.mdi.tools.log.debug("#{user_agent_class.agent_name}: new incomming presence:\n#{presence.inspect}")
+        RAGENT.api.mdi.tools.log.debug("#{user_agent_class.agent_name}: new incoming presence:\n#{presence.inspect}")
         PUNK.end('new','ok','in',"AGENT:#{user_agent_class.agent_name}TNEGA <- PRESENCE [#{presence.type}]")
 
 
@@ -119,7 +119,7 @@ module RagentIncomingMessage
     return unless RAGENT.supported_message_channels.include? channel || RAGENT.supported_message_channels.include?('ALL_CHANNELS')
 
     PUNK.start('new')
-    RAGENT.api.mdi.tools.log.debug("\n\n\n\nServer: new incomming message:\n#{params}")
+    RAGENT.api.mdi.tools.log.debug("\n\n\n\nServer: new incoming message:\n#{params}")
     SDK_STATS.stats['server']['received'][1] += 1
 
     # vm-mode jBinaryGate: ack the message
@@ -227,7 +227,7 @@ module RagentIncomingMessage
           end
 
           PUNK.start('new')
-          RAGENT.api.mdi.tools.log.debug("#{user_agent_class.agent_name}: new incomming message:\n#{ragent_msg.inspect}")
+          RAGENT.api.mdi.tools.log.debug("#{user_agent_class.agent_name}: new incoming message:\n#{ragent_msg.inspect}")
           PUNK.end('new','ok','in',"AGENT:#{user_agent_class.agent_name}TNEGA <- MESSAGE [#{ragent_msg.channel}]")
 
           # process it, should never fail, but if its happen we will have a wrong error on parse fail but no deadlock
@@ -264,7 +264,7 @@ module RagentIncomingMessage
     end
 
     PUNK.start('new')
-    RAGENT.api.mdi.tools.log.debug("\n\n\n\nServer: new incomming track:\n#{params}")
+    RAGENT.api.mdi.tools.log.debug("\n\n\n\nServer: new incoming track:\n#{params}")
     PUNK.end('new', 'ok', 'in', "SERVER <- TRACK : receive new track")
     SDK_STATS.stats['server']['received'][2] += 1
 
@@ -315,7 +315,7 @@ module RagentIncomingMessage
         PUNK.start('new')
         # injected cache (vm mode)
         track = TrackCache.inject_cache(track) if RAGENT.running_env_name == 'sdk-vm' and io_rule['track_fields_cached'] != nil and io_rule['track_fields_cached'] == true
-        RAGENT.api.mdi.tools.log.debug("#{user_agent_class.agent_name}: new incomming track:\n#{track.inspect}")
+        RAGENT.api.mdi.tools.log.debug("#{user_agent_class.agent_name}: new incoming track:\n#{track.inspect}")
         str_field_cached = " (#{track.meta['fields_cached'].size / 2})" if track.meta['fields_cached'].is_a? Hash
         PUNK.end('new','ok','in',"AGENT:#{user_agent_class.agent_name}TNEGA <- TRACK [#{track.fields_data.size} fields#{str_field_cached}]")
 
@@ -354,7 +354,7 @@ module RagentIncomingMessage
     end
 
     PUNK.start('new')
-    RAGENT.api.mdi.tools.log.debug("\n\n\n\nServer: new incomming order:\n#{params}")
+    RAGENT.api.mdi.tools.log.debug("\n\n\n\nServer: new incoming order:\n#{params}")
     SDK_STATS.stats['server']['received'][3] += 1
     PUNK.end('new','ok','in',"SERVER <- ORDER for agent '#{assigned_agent.agent_name}'")
 
@@ -376,7 +376,7 @@ module RagentIncomingMessage
       # No need to check route loop (i guess)
 
       PUNK.start('new')
-      RAGENT.api.mdi.tools.log.debug("#{assigned_agent.agent_name}: new incomming order:#{order.inspect}")
+      RAGENT.api.mdi.tools.log.debug("#{assigned_agent.agent_name}: new incoming order:#{order.inspect}")
       PUNK.end('new','ok','in',"AGENT:#{assigned_agent.agent_name}TNEGA <- ORDER [#{order.code}]")
 
       # process it, should never fail, but if its happen we will have a wrong error on parse fail but no deadlock
@@ -414,7 +414,7 @@ module RagentIncomingMessage
     end
 
     PUNK.start('new')
-    RAGENT.api.mdi.tools.log.debug("\n\n\n\nServer: new incomming collection:\n#{params}")
+    RAGENT.api.mdi.tools.log.debug("\n\n\n\nServer: new incoming collection:\n#{params}")
     PUNK.end('new','ok','in',"SERVER <- COLLECTION : receive new collection")
     SDK_STATS.stats['server']['received'][4] += 1
 
@@ -456,7 +456,7 @@ module RagentIncomingMessage
         end
 
         PUNK.start('new')
-        RAGENT.api.mdi.tools.log.debug("#{user_agent_class.agent_name}: new incomming collection:\n#{collection.inspect}")
+        RAGENT.api.mdi.tools.log.debug("#{user_agent_class.agent_name}: new incoming collection:\n#{collection.inspect}")
         PUNK.end('new','ok','in',"AGENT:#{user_agent_class.agent_name}TNEGA <- COLLECTION [#{collection.name}]")
 
         # process it, should never fail, but if its happen we will have a wrong error on parse fail but no deadlock
@@ -487,7 +487,7 @@ module RagentIncomingMessage
     end
 
     PUNK.start('new')
-    RAGENT.api.mdi.tools.log.debug("\n\n\n\nServer: new incomming poke:\n#{params}")
+    RAGENT.api.mdi.tools.log.debug("\n\n\n\nServer: new incoming poke:\n#{params}")
     PUNK.end('new','ok','in',"SERVER <- POKE : receive new poke")
     SDK_STATS.stats['server']['received'][6] += 1
 
@@ -524,7 +524,7 @@ module RagentIncomingMessage
 
 
         PUNK.start('new')
-        RAGENT.api.mdi.tools.log.debug("#{user_agent_class.agent_name}: new incomming poke:\n#{poke.inspect}")
+        RAGENT.api.mdi.tools.log.debug("#{user_agent_class.agent_name}: new incoming poke:\n#{poke.inspect}")
         PUNK.end('new','ok','in',"AGENT:#{user_agent_class.agent_name}TNEGA <- POKE")
 
         # process it, should never fail, but if its happen we will have a wrong error on parse fail but no deadlock

--- a/user_api/com/mdi/dialog/track.rb
+++ b/user_api/com/mdi/dialog/track.rb
@@ -117,7 +117,23 @@ module UserApis
 
             self.fields_data = []
             dropped_fields = []
-            payload.each do |k, v|
+
+            unless payload['fields']
+              payload['fields'] = []
+              payload.each do |k, v|
+                field = apis.mdi.storage.tracking_fields_info.get_by_id(k, true)
+                next if field == nil
+                payload['fields'] << {
+                  'id' => k,
+                  'name' => field['name'],
+                  'data' => v
+                }
+              end
+            end
+
+            payload['fields'].each do |track_field|
+              k = track_field['id']
+              v = track_field['data']
               field = apis.mdi.storage.tracking_fields_info.get_by_id(k, true)
               next if field == nil
               RAGENT.api.mdi.tools.log.debug("init track with track gives #{k} #{v} #{field}")

--- a/user_api/com/mdi/dialog/track.rb
+++ b/user_api/com/mdi/dialog/track.rb
@@ -124,7 +124,7 @@ module UserApis
                 field = apis.mdi.storage.tracking_fields_info.get_by_id(k, true)
                 next if field == nil
                 payload['fields'] << {
-                  'id' => k,
+                  'id' => k.to_i,
                   'name' => field['name'],
                   'data' => v
                 }
@@ -234,7 +234,7 @@ module UserApis
               if field['fresh'] and field['field'] > 4999 # can't inject field from 0 to 4999, device protected
                 CC.logger.debug("to_hash_to_send_to_cloud: Adding field '#{field['field']}' with val= #{field['value']}")
                 r_hash['payload']["#{field['field']}"] = "#{field['raw_value']}"
-                r_hash['payload']['fields'] << {'id' => "#{field['field']}", 'name' => "#{field['name']}", 'data' => "#{field['raw_value']}"}
+                r_hash['payload']['fields'] << {'id' => field['field'], 'name' => "#{field['name']}", 'data' => "#{field['raw_value']}"}
                 a_field = true
                 r_hash['meta']['include_fresh_track_field'] = true
               else

--- a/user_api/com/mdi/dialog/track.rb
+++ b/user_api/com/mdi/dialog/track.rb
@@ -213,10 +213,12 @@ module UserApis
           #add  fresh field of new data (and convert it as magic string)
           a_field = false
           if self.fields_data.is_a? Array # in cas on nil or whatever
+            r_hash['payload']['fields'] = []
             self.fields_data.each do |field|
               if field['fresh'] and field['field'] > 4999 # can't inject field from 0 to 4999, device protected
                 CC.logger.debug("to_hash_to_send_to_cloud: Adding field '#{field['field']}' with val= #{field['value']}")
                 r_hash['payload']["#{field['field']}"] = "#{field['raw_value']}"
+                r_hash['payload']['fields'] << {'id' => "#{field['field']}", 'name' => "#{field['name']}", 'data' => "#{field['raw_value']}"}
                 a_field = true
                 r_hash['meta']['include_fresh_track_field'] = true
               else
@@ -272,6 +274,7 @@ module UserApis
             end
           end
 
+          field['name'] = name
           field['raw_value'] = raw_value
           field['value'] = value
           field['fresh'] = true

--- a/user_api/com/mdi/dialog/track.rb
+++ b/user_api/com/mdi/dialog/track.rb
@@ -204,8 +204,12 @@ module UserApis
             #add field of new data (and convert it as magic string)
             self.fields_data.each do |field|
               CC.logger.debug("to_hash: Adding field '#{field['field']}' with val= #{field['value']}")
+
+              # [DEPRECATED] Old track format
               r_hash['payload'][field['field'].to_s] = "#{field['raw_value']}"
-            end
+              # New track format
+              r_hash['payload']['fields'] << {'id' => field['field'], 'name' => "#{field['name']}", 'data' => "#{field['raw_value']}"}
+          end
           end
 
           r_hash['meta'].delete_if { |k, v| v.nil? }


### PR DESCRIPTION
- Fields are now available in the `fields` attribute of a track (array of fields)
- The three available attributes are `id`, `name` and `data`
- The old format coexists with the new format
